### PR TITLE
Game foundation with chat

### DIFF
--- a/Assets/Scripts/LiveChat/ChatCommandContext.cs
+++ b/Assets/Scripts/LiveChat/ChatCommandContext.cs
@@ -1,0 +1,89 @@
+using LiveChat;
+
+namespace LiveChat.Commands
+{
+    public sealed class ChatCommandContext
+    {
+        public ChatCommandRouter Router { get; }
+        public LiveChatClientBase Client { get; }
+        public LiveChatMessage Message { get; }
+        public string RawText { get; }
+        public string Command { get; }
+        public string ArgsRaw { get; }
+        public string[] Args { get; }
+
+        public string Channel => !string.IsNullOrEmpty(Message?.Channel)
+            ? Message.Channel
+            : Client?.DefaultChannel ?? string.Empty;
+
+        public string Username => Message?.Username ?? string.Empty;
+        public string DisplayName => string.IsNullOrEmpty(Message?.DisplayName) ? Username : Message.DisplayName;
+
+        public bool IsSubscriber => Message != null && Message.IsSubscriber;
+        public bool IsVip => Message != null && Message.IsVip;
+        public bool IsModerator => Message != null && Message.IsModerator;
+        public bool IsBroadcaster => Message != null && Message.IsBroadcaster;
+        public bool IsMe => Message != null && Message.IsMe;
+
+        public ChatCommandContext(ChatCommandRouter router, LiveChatClientBase client, LiveChatMessage message,
+            string rawText, string command, string argsRaw, string[] args)
+        {
+            Router = router;
+            Client = client;
+            Message = message;
+            RawText = rawText;
+            Command = command;
+            ArgsRaw = argsRaw;
+            Args = args ?? System.Array.Empty<string>();
+        }
+
+        public bool HasPermission(ChatCommandPermission permission)
+        {
+            if (Message == null)
+                return true;
+
+            switch (permission)
+            {
+                case ChatCommandPermission.Anyone:
+                    return true;
+                case ChatCommandPermission.Subscriber:
+                    return IsSubscriber || IsVip || IsModerator || IsBroadcaster;
+                case ChatCommandPermission.Vip:
+                    return IsVip || IsModerator || IsBroadcaster;
+                case ChatCommandPermission.Moderator:
+                    return IsModerator || IsBroadcaster;
+                case ChatCommandPermission.Broadcaster:
+                    return IsBroadcaster;
+                default:
+                    return false;
+            }
+        }
+
+        public void Reply(string message)
+        {
+            if (Client == null || string.IsNullOrEmpty(message))
+                return;
+
+            string channel = Channel;
+            if (string.IsNullOrEmpty(channel))
+                return;
+
+            if (!string.IsNullOrEmpty(Message?.MessageId))
+                Client.SendReply(channel, Message.MessageId, message);
+            else
+                Client.SendMessage(channel, message);
+        }
+
+        public void Say(string message)
+        {
+            if (Client == null || string.IsNullOrEmpty(message))
+                return;
+
+            string channel = Channel;
+            if (string.IsNullOrEmpty(channel))
+                return;
+
+            Client.SendMessage(channel, message);
+        }
+    }
+}

--- a/Assets/Scripts/LiveChat/ChatCommandContext.cs.meta
+++ b/Assets/Scripts/LiveChat/ChatCommandContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a9f4ac2f6b4473db16d0297c2b39d65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LiveChat/ChatCommandEcho.cs
+++ b/Assets/Scripts/LiveChat/ChatCommandEcho.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+namespace LiveChat.Commands
+{
+    public class ChatCommandEcho : ChatCommandHandler
+    {
+        [SerializeField] private bool _replyAsBot = true;
+        [SerializeField] private bool _allowEmptyMessage = false;
+
+        private void Reset()
+        {
+            SetDefaults(
+                command: "echo",
+                description: "Repeats a message back to chat.",
+                usage: "!echo <message>",
+                minimumPermission: ChatCommandPermission.Moderator,
+                aliases: new[] { "say" });
+        }
+
+        public override void Execute(ChatCommandContext context)
+        {
+            if (context == null)
+                return;
+
+            if (context.Args.Length == 0)
+            {
+                if (_allowEmptyMessage)
+                    return;
+
+                context.Reply("Usage: !echo <message>");
+                return;
+            }
+
+            string message = context.ArgsRaw;
+            if (_replyAsBot)
+                context.Reply(message);
+            else
+                context.Say(message);
+        }
+    }
+}

--- a/Assets/Scripts/LiveChat/ChatCommandEcho.cs.meta
+++ b/Assets/Scripts/LiveChat/ChatCommandEcho.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2e7f7fdb6cd4b2ba46cb5e6b4f8d337
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LiveChat/ChatCommandHandler.cs
+++ b/Assets/Scripts/LiveChat/ChatCommandHandler.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LiveChat.Commands
+{
+    public abstract class ChatCommandHandler : MonoBehaviour
+    {
+        [SerializeField] private string _command = string.Empty;
+        [SerializeField] private string[] _aliases = new string[0];
+        [SerializeField, TextArea(1, 3)] private string _description = string.Empty;
+        [SerializeField] private string _usage = string.Empty;
+        [SerializeField] private ChatCommandPermission _minimumPermission = ChatCommandPermission.Anyone;
+
+        public string Command => _command;
+        public IReadOnlyList<string> Aliases => _aliases;
+        public string Description => _description;
+        public string Usage => _usage;
+        public ChatCommandPermission MinimumPermission => _minimumPermission;
+
+        public virtual bool CanExecute(ChatCommandContext context)
+        {
+            return context != null && context.HasPermission(_minimumPermission);
+        }
+
+        public bool Matches(string command, StringComparer comparer)
+        {
+            if (string.IsNullOrWhiteSpace(command))
+                return false;
+
+            if (!string.IsNullOrEmpty(_command) && comparer.Equals(_command, command))
+                return true;
+
+            if (_aliases == null)
+                return false;
+
+            for (int i = 0; i < _aliases.Length; i++)
+            {
+                if (string.IsNullOrEmpty(_aliases[i]))
+                    continue;
+
+                if (comparer.Equals(_aliases[i], command))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public abstract void Execute(ChatCommandContext context);
+
+        protected void SetDefaults(string command, string description, string usage,
+            ChatCommandPermission minimumPermission, params string[] aliases)
+        {
+            _command = command ?? string.Empty;
+            _description = description ?? string.Empty;
+            _usage = usage ?? string.Empty;
+            _minimumPermission = minimumPermission;
+            _aliases = aliases ?? Array.Empty<string>();
+        }
+    }
+}

--- a/Assets/Scripts/LiveChat/ChatCommandHandler.cs.meta
+++ b/Assets/Scripts/LiveChat/ChatCommandHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c19b2f0f2b8450c88c9b1bb343a0db5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LiveChat/ChatCommandHelp.cs
+++ b/Assets/Scripts/LiveChat/ChatCommandHelp.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LiveChat.Commands
+{
+    public class ChatCommandHelp : ChatCommandHandler
+    {
+        [SerializeField] private ChatCommandRouter _router;
+        [SerializeField] private int _maxEntriesPerMessage = 6;
+        [SerializeField] private bool _includeAliasesInDetails = true;
+
+        private void Reset()
+        {
+            SetDefaults(
+                command: "help",
+                description: "Shows available chat commands.",
+                usage: "!help [command]",
+                minimumPermission: ChatCommandPermission.Anyone,
+                aliases: new[] { "commands" });
+        }
+
+        private void Awake()
+        {
+            if (_router == null)
+                _router = GetComponentInParent<ChatCommandRouter>();
+        }
+
+        public override void Execute(ChatCommandContext context)
+        {
+            if (context == null)
+                return;
+
+            ChatCommandRouter router = _router != null ? _router : context.Router;
+            if (router == null)
+            {
+                context.Reply("Help is not configured.");
+                return;
+            }
+
+            if (context.Args.Length > 0)
+            {
+                string query = router.NormalizeCommand(context.Args[0]);
+                ChatCommandHandler handler = router.FindHandler(query);
+                if (handler == null)
+                {
+                    context.Reply($"No command found for \"{query}\".");
+                    return;
+                }
+
+                string prefix = router.PrimaryPrefix;
+                string description = string.IsNullOrEmpty(handler.Description) ? string.Empty : $" - {handler.Description}";
+                string usage = string.IsNullOrEmpty(handler.Usage) ? string.Empty : $" Usage: {handler.Usage}";
+                string aliases = string.Empty;
+
+                if (_includeAliasesInDetails && handler.Aliases != null && handler.Aliases.Count > 0)
+                    aliases = $" Aliases: {FormatAliases(prefix, handler.Aliases)}";
+
+                context.Reply($"{prefix}{handler.Command}{description}{usage}{aliases}");
+                return;
+            }
+
+            List<string> available = new List<string>();
+            for (int i = 0; i < router.Handlers.Count; i++)
+            {
+                ChatCommandHandler handler = router.Handlers[i];
+                if (handler == null || !handler.isActiveAndEnabled)
+                    continue;
+                if (!handler.CanExecute(context))
+                    continue;
+                if (string.IsNullOrWhiteSpace(handler.Command))
+                    continue;
+
+                available.Add($"{router.PrimaryPrefix}{handler.Command}");
+            }
+
+            if (available.Count == 0)
+            {
+                context.Reply("No commands available.");
+                return;
+            }
+
+            SendBatched(context, "Commands: ", available, _maxEntriesPerMessage);
+        }
+
+        private static void SendBatched(ChatCommandContext context, string prefix, List<string> commands, int maxPerMessage)
+        {
+            if (maxPerMessage <= 0)
+                maxPerMessage = commands.Count;
+
+            for (int i = 0; i < commands.Count; i += maxPerMessage)
+            {
+                int count = Mathf.Min(maxPerMessage, commands.Count - i);
+                string message = prefix + string.Join(", ", commands.GetRange(i, count));
+                context.Reply(message);
+                prefix = string.Empty;
+            }
+        }
+
+        private static string FormatAliases(string prefix, IReadOnlyList<string> aliases)
+        {
+            List<string> formatted = new List<string>();
+            for (int i = 0; i < aliases.Count; i++)
+            {
+                if (string.IsNullOrEmpty(aliases[i]))
+                    continue;
+
+                formatted.Add($"{prefix}{aliases[i]}");
+            }
+
+            return string.Join(", ", formatted);
+        }
+    }
+}

--- a/Assets/Scripts/LiveChat/ChatCommandHelp.cs.meta
+++ b/Assets/Scripts/LiveChat/ChatCommandHelp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99d9db1b7d4a4c1aa5305df9ee5d4fd9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LiveChat/ChatCommandParser.cs
+++ b/Assets/Scripts/LiveChat/ChatCommandParser.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LiveChat.Commands
+{
+    public readonly struct ChatCommandParseResult
+    {
+        public string Prefix { get; }
+        public string Command { get; }
+        public string ArgsRaw { get; }
+        public string[] Args { get; }
+        public string RawText { get; }
+
+        public ChatCommandParseResult(string prefix, string command, string argsRaw, string[] args, string rawText)
+        {
+            Prefix = prefix;
+            Command = command;
+            ArgsRaw = argsRaw;
+            Args = args ?? Array.Empty<string>();
+            RawText = rawText;
+        }
+    }
+
+    public static class ChatCommandParser
+    {
+        public static bool TryParse(string rawMessage, string[] prefixes, bool ignoreCase, out ChatCommandParseResult result)
+        {
+            result = default;
+            if (string.IsNullOrWhiteSpace(rawMessage))
+                return false;
+
+            if (prefixes == null || prefixes.Length == 0)
+                return false;
+
+            string trimmed = rawMessage.TrimStart();
+            string matchedPrefix = null;
+            foreach (string prefix in prefixes)
+            {
+                if (string.IsNullOrEmpty(prefix))
+                    continue;
+
+                if (trimmed.StartsWith(prefix, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                {
+                    matchedPrefix = prefix;
+                    break;
+                }
+            }
+
+            if (matchedPrefix == null)
+                return false;
+
+            string commandText = trimmed.Substring(matchedPrefix.Length).TrimStart();
+            if (string.IsNullOrEmpty(commandText))
+                return false;
+
+            string command;
+            string argsRaw;
+            int whitespaceIndex = IndexOfWhitespace(commandText);
+            if (whitespaceIndex < 0)
+            {
+                command = commandText;
+                argsRaw = string.Empty;
+            }
+            else
+            {
+                command = commandText.Substring(0, whitespaceIndex);
+                argsRaw = commandText.Substring(whitespaceIndex + 1).TrimStart();
+            }
+
+            string[] args = ParseArguments(argsRaw);
+            result = new ChatCommandParseResult(matchedPrefix, command, argsRaw, args, trimmed);
+            return true;
+        }
+
+        public static string[] ParseArguments(string argsRaw)
+        {
+            if (string.IsNullOrWhiteSpace(argsRaw))
+                return Array.Empty<string>();
+
+            List<string> args = new List<string>();
+            StringBuilder current = new StringBuilder();
+            bool inQuotes = false;
+            char quoteChar = '\0';
+
+            for (int i = 0; i < argsRaw.Length; i++)
+            {
+                char c = argsRaw[i];
+                if (inQuotes)
+                {
+                    if (c == '\\' && i + 1 < argsRaw.Length)
+                    {
+                        char next = argsRaw[i + 1];
+                        if (next == quoteChar || next == '\\')
+                        {
+                            current.Append(next);
+                            i++;
+                            continue;
+                        }
+                    }
+
+                    if (c == quoteChar)
+                    {
+                        inQuotes = false;
+                        continue;
+                    }
+
+                    current.Append(c);
+                    continue;
+                }
+
+                if (char.IsWhiteSpace(c))
+                {
+                    if (current.Length > 0)
+                    {
+                        args.Add(current.ToString());
+                        current.Clear();
+                    }
+                    continue;
+                }
+
+                if (IsQuote(c))
+                {
+                    inQuotes = true;
+                    quoteChar = c;
+                    continue;
+                }
+
+                if (c == '\\' && i + 1 < argsRaw.Length)
+                {
+                    char next = argsRaw[i + 1];
+                    if (next == '"' || next == '\'' || next == '\\' || char.IsWhiteSpace(next))
+                    {
+                        current.Append(next);
+                        i++;
+                        continue;
+                    }
+                }
+
+                current.Append(c);
+            }
+
+            if (current.Length > 0)
+                args.Add(current.ToString());
+
+            return args.ToArray();
+        }
+
+        private static int IndexOfWhitespace(string text)
+        {
+            for (int i = 0; i < text.Length; i++)
+            {
+                if (char.IsWhiteSpace(text[i]))
+                    return i;
+            }
+
+            return -1;
+        }
+
+        private static bool IsQuote(char value) => value == '"' || value == '\'';
+    }
+}

--- a/Assets/Scripts/LiveChat/ChatCommandParser.cs.meta
+++ b/Assets/Scripts/LiveChat/ChatCommandParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6508e3ad9c144bcb5106e0dcbab3e68
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LiveChat/ChatCommandPermission.cs
+++ b/Assets/Scripts/LiveChat/ChatCommandPermission.cs
@@ -1,0 +1,11 @@
+namespace LiveChat.Commands
+{
+    public enum ChatCommandPermission
+    {
+        Anyone,
+        Subscriber,
+        Vip,
+        Moderator,
+        Broadcaster
+    }
+}

--- a/Assets/Scripts/LiveChat/ChatCommandPermission.cs.meta
+++ b/Assets/Scripts/LiveChat/ChatCommandPermission.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4f6e0f4cf4b4f64a1d4f84b9e5f8b21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LiveChat/ChatCommandPing.cs
+++ b/Assets/Scripts/LiveChat/ChatCommandPing.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+namespace LiveChat.Commands
+{
+    public class ChatCommandPing : ChatCommandHandler
+    {
+        [SerializeField] private string _reply = "Pong!";
+
+        private void Reset()
+        {
+            SetDefaults(
+                command: "ping",
+                description: "Quick connectivity check.",
+                usage: "!ping",
+                minimumPermission: ChatCommandPermission.Anyone);
+        }
+
+        public override void Execute(ChatCommandContext context)
+        {
+            if (context == null)
+                return;
+
+            context.Reply(_reply);
+        }
+    }
+}

--- a/Assets/Scripts/LiveChat/ChatCommandPing.cs.meta
+++ b/Assets/Scripts/LiveChat/ChatCommandPing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5db5f31f6ffb4c9bb0f8d721b1f9b2d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LiveChat/ChatCommandRouter.cs
+++ b/Assets/Scripts/LiveChat/ChatCommandRouter.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LiveChat.Commands
+{
+    public class ChatCommandRouter : MonoBehaviour
+    {
+        [Header("Chat Source")]
+        [SerializeField] private LiveChatClientBase _client;
+
+        [Header("Command Parsing")]
+        [SerializeField] private string[] _commandPrefixes = new string[] { "!" };
+        [SerializeField] private bool _ignoreCase = true;
+
+        [Header("Handler Discovery")]
+        [SerializeField] private bool _autoDiscoverHandlers = true;
+        [SerializeField] private Transform _handlerRoot;
+        [SerializeField] private bool _includeInactiveHandlers = true;
+        [SerializeField] private List<ChatCommandHandler> _manualHandlers = new List<ChatCommandHandler>();
+
+        [Header("Responses")]
+        [SerializeField] private bool _replyOnPermissionDenied = false;
+        [SerializeField] private string _permissionDeniedMessage = "You don't have permission to use {command}.";
+        [SerializeField] private bool _replyOnUnknownCommand = false;
+        [SerializeField] private string _unknownCommandMessage = "Unknown command: {command}";
+        [SerializeField] private bool _logCommands = false;
+        [SerializeField] private bool _logUnknownCommands = true;
+
+        private readonly List<ChatCommandHandler> _handlerCache = new List<ChatCommandHandler>();
+        private Dictionary<string, List<ChatCommandHandler>> _handlerLookup;
+        private StringComparer _commandComparer;
+
+        public IReadOnlyList<ChatCommandHandler> Handlers => _handlerCache;
+        public string PrimaryPrefix => _commandPrefixes != null && _commandPrefixes.Length > 0 ? _commandPrefixes[0] : "!";
+
+        private void Awake()
+        {
+            BuildComparer();
+            RefreshHandlers();
+        }
+
+        private void OnEnable()
+        {
+            if (_client == null)
+                _client = GetComponent<LiveChatClientBase>();
+
+            if (_client != null)
+                _client.MessageReceived += OnMessageReceived;
+        }
+
+        private void OnDisable()
+        {
+            if (_client != null)
+                _client.MessageReceived -= OnMessageReceived;
+        }
+
+        private void OnValidate()
+        {
+            BuildComparer();
+        }
+
+        public void RefreshHandlers()
+        {
+            _handlerCache.Clear();
+
+            if (_manualHandlers != null)
+                AddHandlers(_manualHandlers);
+
+            if (_autoDiscoverHandlers)
+            {
+                Transform root = _handlerRoot != null ? _handlerRoot : transform;
+                ChatCommandHandler[] discovered = root.GetComponentsInChildren<ChatCommandHandler>(_includeInactiveHandlers);
+                AddHandlers(discovered);
+            }
+
+            RebuildLookup();
+        }
+
+        public void RegisterHandler(ChatCommandHandler handler)
+        {
+            if (handler == null || _handlerCache.Contains(handler))
+                return;
+
+            _handlerCache.Add(handler);
+            RegisterCommand(handler.Command, handler);
+            var aliases = handler.Aliases;
+            if (aliases == null)
+                return;
+
+            for (int i = 0; i < aliases.Count; i++)
+                RegisterCommand(aliases[i], handler);
+        }
+
+        public void UnregisterHandler(ChatCommandHandler handler)
+        {
+            if (handler == null)
+                return;
+
+            if (_handlerCache.Remove(handler))
+                RebuildLookup();
+        }
+
+        public ChatCommandHandler FindHandler(string command)
+        {
+            if (string.IsNullOrWhiteSpace(command) || _handlerLookup == null)
+                return null;
+
+            if (!_handlerLookup.TryGetValue(command, out List<ChatCommandHandler> handlers))
+                return null;
+
+            for (int i = 0; i < handlers.Count; i++)
+            {
+                var handler = handlers[i];
+                if (handler != null && handler.isActiveAndEnabled)
+                    return handler;
+            }
+
+            return null;
+        }
+
+        public string NormalizeCommand(string command)
+        {
+            if (string.IsNullOrWhiteSpace(command))
+                return string.Empty;
+
+            string trimmed = command.Trim();
+            if (_commandPrefixes == null)
+                return trimmed;
+
+            for (int i = 0; i < _commandPrefixes.Length; i++)
+            {
+                string prefix = _commandPrefixes[i];
+                if (string.IsNullOrEmpty(prefix))
+                    continue;
+
+                if (trimmed.StartsWith(prefix, _ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                    return trimmed.Substring(prefix.Length);
+            }
+
+            return trimmed;
+        }
+
+        public bool ProcessMessage(LiveChatMessage message)
+        {
+            if (message == null)
+                return false;
+
+            if (!ChatCommandParser.TryParse(message.RawMessage, _commandPrefixes, _ignoreCase, out ChatCommandParseResult parsed))
+                return false;
+
+            ChatCommandHandler handler = FindHandler(parsed.Command);
+            if (handler == null)
+            {
+                if (_logUnknownCommands)
+                    Debug.Log($"[ChatCommandRouter] Unknown command '{parsed.Command}'.");
+                if (_replyOnUnknownCommand)
+                {
+                    ChatCommandContext context = new ChatCommandContext(this, _client, message, parsed.RawText, parsed.Command, parsed.ArgsRaw, parsed.Args);
+                    context.Reply(_unknownCommandMessage.Replace("{command}", parsed.Command));
+                }
+                return false;
+            }
+
+            ChatCommandContext commandContext = new ChatCommandContext(this, _client, message, parsed.RawText, parsed.Command, parsed.ArgsRaw, parsed.Args);
+            if (!handler.CanExecute(commandContext))
+            {
+                if (_replyOnPermissionDenied)
+                    commandContext.Reply(_permissionDeniedMessage.Replace("{command}", parsed.Command));
+                return false;
+            }
+
+            if (_logCommands)
+                Debug.Log($"[ChatCommandRouter] {commandContext.Username}: {parsed.Command} {parsed.ArgsRaw}");
+
+            try
+            {
+                handler.Execute(commandContext);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+            }
+
+            return true;
+        }
+
+        private void OnMessageReceived(LiveChatMessage message)
+        {
+            ProcessMessage(message);
+        }
+
+        private void AddHandlers(IEnumerable<ChatCommandHandler> handlers)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (var handler in handlers)
+            {
+                if (handler == null || _handlerCache.Contains(handler))
+                    continue;
+
+                _handlerCache.Add(handler);
+            }
+        }
+
+        private void RebuildLookup()
+        {
+            if (_handlerLookup == null || _handlerLookup.Comparer != _commandComparer)
+                BuildComparer();
+            else
+                _handlerLookup.Clear();
+
+            for (int i = 0; i < _handlerCache.Count; i++)
+            {
+                ChatCommandHandler handler = _handlerCache[i];
+                if (handler == null)
+                    continue;
+
+                RegisterCommand(handler.Command, handler);
+                var aliases = handler.Aliases;
+                if (aliases == null)
+                    continue;
+
+                for (int aliasIndex = 0; aliasIndex < aliases.Count; aliasIndex++)
+                    RegisterCommand(aliases[aliasIndex], handler);
+            }
+        }
+
+        private void RegisterCommand(string command, ChatCommandHandler handler)
+        {
+            if (string.IsNullOrWhiteSpace(command) || handler == null)
+                return;
+
+            if (!_handlerLookup.TryGetValue(command, out List<ChatCommandHandler> list))
+            {
+                list = new List<ChatCommandHandler>();
+                _handlerLookup[command] = list;
+            }
+
+            if (!list.Contains(handler))
+                list.Add(handler);
+        }
+
+        private void BuildComparer()
+        {
+            _commandComparer = _ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            _handlerLookup = new Dictionary<string, List<ChatCommandHandler>>(_commandComparer);
+        }
+    }
+}

--- a/Assets/Scripts/LiveChat/ChatCommandRouter.cs.meta
+++ b/Assets/Scripts/LiveChat/ChatCommandRouter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b3172eb9c874a81a83b39fb3e4d35a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ platform-neutral message/event models and Twitch implementations:
 - `LiveChat.Twitch.TwitchPubSubClient` for bits, redemptions, and subs
 - `LiveChat.YouTube.YouTubeLiveChatClient` is a stub you can wire to YouTube Data API
 
+## Chat Command Foundation
+
+For building chat-driven game ideas, there is a command routing layer in
+`Assets/Scripts/LiveChat` under the `LiveChat.Commands` namespace:
+
+- `ChatCommandRouter` listens to `LiveChatClientBase` messages and dispatches commands
+- `ChatCommandHandler` is the base class for new commands
+- `ChatCommandHelp`, `ChatCommandPing`, and `ChatCommandEcho` are example handlers
+
+Quick setup:
+
+1. Add `TwitchLiveChatClient` (or another `LiveChatClientBase`) to a GameObject.
+2. Add `ChatCommandRouter` to the same object and set the command prefix (default `!`).
+3. Add one or more `ChatCommandHandler` components as children of the router.
+4. Create new commands by deriving from `ChatCommandHandler` and overriding
+   `Execute(ChatCommandContext context)`.
+
+The parser supports quoted arguments, for example: `!spawn "big boss" 3`.
+
 ## Contribute
 
 Please read the CONTRIBUTING.md file (TODO) for how you can contribute to this project and what is important.


### PR DESCRIPTION
Add a chat command foundation with router, parser, and handler base to enable chat-based game control.

This PR introduces a reusable system for processing chat messages as commands, including a router, parser, command context, permission handling, and an abstract base for command handlers. Example commands (`Help`, `Ping`, `Echo`) are included, and the setup is documented in the README. This directly addresses the user's request for a foundation to build chat-controlled game ideas.

---
<a href="https://cursor.com/background-agent?bcId=bc-a2b8276a-924f-43b8-a503-6260528077a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a2b8276a-924f-43b8-a503-6260528077a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

